### PR TITLE
Force ignore cert checking on irc scraper, as all the synirc certs are e...

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ No pull requests will be accepted to any branch except the dev branch.
 New updates are grouped by person, at the top of the file.
 
 2014-09-01 kevin
+	* Chg: Force ignore cert checking on irc scraper, as all the synirc certs are either expired or self signed or invalid in some other way.
 	* Add: Support for openssl remote certificate checking on streams/CURL. Please update www/config.php using this guide: https://github.com/nZEDb/nZEDb/wiki/Setting-up-openssl
 	* Fix: Namespacing issue in DB.
 2014-09-01 niel

--- a/nzedb/build/nZEDb.xml
+++ b/nzedb/build/nZEDb.xml
@@ -7,7 +7,7 @@
 		</sql>
 		<git>
 			<tag>0.3.2</tag>
-			<commit>9378</commit>
+			<commit>9379</commit>
 			<hooks>
 				<precommit>9</precommit>
 				<!-- this is the version of the pre-commit file in githooks NOT the files it calls -->

--- a/nzedb/controllers/IRCClient.php
+++ b/nzedb/controllers/IRCClient.php
@@ -626,7 +626,7 @@ class IRCClient
 			$error_string,
 			$this->_remote_connection_timeout,
 			STREAM_CLIENT_CONNECT,
-			stream_context_create(nzedb\utility\Utility::streamSslContextOptions())
+			stream_context_create(nzedb\utility\Utility::streamSslContextOptions(true))
 		);
 
 		if ($socket === false) {

--- a/nzedb/utility/Utility.php
+++ b/nzedb/utility/Utility.php
@@ -275,16 +275,18 @@ class Utility
 	 * Creates an array to be used with stream_context_create() to verify openssl certificates
 	 * when connecting to a tls or ssl connection when using stream functions (fopen/file_get_contents/etc).
 	 *
+	 * @param bool $forceIgnore Force ignoring of verification.
+	 *
 	 * @return array
 	 * @static
 	 * @access public
 	 */
-	static public function streamSslContextOptions()
+	static public function streamSslContextOptions($forceIgnore = false)
 	{
 		$options = [
-			'verify_peer'       => (bool)nZEDb_SSL_VERIFY_PEER,
-			'verify_peer_name'  => (bool)nZEDb_SSL_VERIFY_HOST,
-			'allow_self_signed' => (bool)nZEDb_SSL_ALLOW_SELF_SIGNED,
+			'verify_peer'       => ($forceIgnore ? false : (bool)nZEDb_SSL_VERIFY_PEER),
+			'verify_peer_name'  => ($forceIgnore ? false : (bool)nZEDb_SSL_VERIFY_HOST),
+			'allow_self_signed' => ($forceIgnore ? true : (bool)nZEDb_SSL_ALLOW_SELF_SIGNED),
 		];
 		if (nZEDb_SSL_CAFILE) {
 			$options['cafile'] = nZEDb_SSL_CAFILE;


### PR DESCRIPTION
...ither expired or self signed or invalid in some other way.
